### PR TITLE
Change routes and tests appropriately

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -6,7 +6,7 @@ const Router = Ember.Router.extend({
   rootURL: config.rootURL
 });
 
-Router.map(function() {
+Router.map(function() { 
   this.route('reminders');
 });
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-
+  beforeModel() {
+   this.replaceWith('reminders');
+  }
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -13,7 +13,7 @@ test('viewing the homepage', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(currentURL(), '/', 'curren turl is root');
+    assert.equal(currentURL(), '/', 'current url is root');
     assert.equal(Ember.$('.spec-reminder-item').length, 5, 'root page user sees 5 reminders');
   });
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -13,7 +13,7 @@ test('viewing the homepage', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(currentURL(), '/', 'current url is root');
+    assert.equal(currentURL(), '/reminders', 'current url is /reminders');
     assert.equal(Ember.$('.spec-reminder-item').length, 5, 'root page user sees 5 reminders');
   });
 });
@@ -25,7 +25,7 @@ skip('clicking on an individual item', function(assert) {
   click('.spec-reminder-item:first');
 
   andThen(function() {
-    assert.equal(currentURL(), '/1');
+    assert.equal(currentURL(), '/reminders');
     assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), Ember.$('.spec-reminder-title').text().trim());
   });
 });


### PR DESCRIPTION
## Purpose
When the user visits the root of the application, they should be redirected to '/reminders' and should see a list of all reminders on the page. This means making a hopefully small adjustment to your router.js file.

[Issue #2](https://github.com/turingschool-projects/1610-remember-1/issues/2)

## Approach
Changed the index route and used "beforeModel" to redirect '/' to '/reminders'

### Learning

We read the docs to find out how to do this and found a great tutorial.

[Ember Routes and Templates ](https://guides.emberjs.com/v2.11.0/tutorial/routes-and-templates/)

### Open Questions and Pre-Merge TODOs

- [x] change index route file
- [x] change test routes to make them pass

### Test coverage 

Changed the path in our tests so that it would pass again

### Follow-up tasks

- [Issue #3](https://github.com/turingschool-projects/1610-remember-1/issues/3)

### Screenshots

#### Before
<img width="318" alt="screen shot 2017-02-09 at 4 42 27 pm" src="https://cloud.githubusercontent.com/assets/20376939/22809472/1ece1f22-eef0-11e6-9a45-15d8505864b7.png">


#### After
<img width="438" alt="screen shot 2017-02-09 at 5 46 08 pm" src="https://cloud.githubusercontent.com/assets/20376939/22809469/18ca47d6-eef0-11e6-8440-f557ad6207ef.png">

<img width="436" alt="screen shot 2017-02-09 at 5 50 21 pm" src="https://cloud.githubusercontent.com/assets/20376939/22809504/492af236-eef0-11e6-97c5-81d6782199da.png">



close #2 
