### PR TITLE
Revert Button Implemented

### DIFF
--- a/app/components/edit-reminder.js
+++ b/app/components/edit-reminder.js
@@ -10,6 +10,9 @@ export default Ember.Component.extend({
   actions: {
     editReminder(model) {
       model.save();
+    },
+    revertReminder(model) {
+      model.rollbackAttributes();
     }
   }
 });

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -18,9 +18,11 @@
       Save
     </button>
   {{/link-to}}
-  <button
-    class='spec-reminder-edit--revert'
-    {{action 'revertReminder' model on="click"}}>
-    Revert
-  </button>
+  {{#if model.hasDirtyAttributes}}
+    <button
+      class='spec-reminder-edit--revert'
+      {{action 'revertReminder' model on="click"}}>
+      Revert
+    </button>
+  {{/if}}
 </form>

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -1,4 +1,4 @@
-<form {{action 'editReminder' model on="submit"}}>
+<form >
   <label>
     Title
     {{input class="spec-edit-input-title" value=model.title}}
@@ -12,6 +12,15 @@
     {{textarea class="spec-edit-textarea-notes" value=model.notes}}
   </label>
   {{#link-to "reminders.reminder-card"}}
-    <button class='spec-reminder-edit--save'>Save</button>
+    <button
+      class='spec-reminder-edit--save'
+      {{action 'editReminder' model on="click"}}>
+      Save
+    </button>
   {{/link-to}}
+  <button
+    class='spec-reminder-edit--revert'
+    {{action 'revertReminder' model on="click"}}>
+    Revert
+  </button>
 </form>

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -79,3 +79,29 @@ test('edit and save fields', function(assert) {
     assert.equal(Ember.$('.spec-reminder-card--date').text().trim(), 'a', 'edit date and updated reminder list on save');
   });
 });
+
+test('edit and revert to original info', function(assert) {
+
+  visit('/');
+  click('.spec-reminder--new');
+  fillIn('.spec-input-title', 'Bananas');
+  fillIn('.spec-input-date', '12/23/16');
+  fillIn('.spec-textarea-notes', 'This shit is bananas, B.A.N.A.N.A.S.');
+  click('.spec-reminder-add--submit');
+  click('.spec-reminder--title');
+  click('.spec-reminder-card--editbtn');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders/1/edit', 'click edit on reminder card takes you to nested edit route');
+  });
+
+  fillIn('.spec-edit-input-title', 'a');
+  fillIn('.spec-edit-input-date', 'a');
+  fillIn('.spec-edit-textarea-notes', 'a');
+  click('.spec-reminder-edit--revert');
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder--title').text().trim(), 'Bananas', 'edit title and reverts to original on button click');
+    assert.equal(Ember.$('.spec-reminder-card--date').text().trim(), '12/23/16', 'edit date and reverts to original on revert button click');
+  });
+});

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -8,30 +8,16 @@ import Ember from 'ember';
 moduleForAcceptance('Acceptance | reminders list');
 
 test('viewing the homepage', function(assert) {
-  server.createList('reminder', 5);
 
   visit('/');
 
   andThen(function() {
     assert.equal(currentURL(), '/reminders', 'current url is /reminders');
-    assert.equal(Ember.$('.spec-reminder-item').length, 5, 'root page user sees 5 reminders');
-  });
-});
-
-test('clicking on an individual item', function(assert) {
-  server.createList('reminder', 5);
-
-  visit('/');
-  click('.spec-reminder--title:first');
-
-  andThen(function() {
-    assert.equal(currentURL(), '/reminders/1', 'click on individual item routes');
-    assert.equal(Ember.$('.spec-reminder--title:first').text().trim(), Ember.$('.spec-reminder-card--title:first').text().trim(), 'title matches clicked card title');
+    assert.equal(Ember.$('.spec-reminder-item').length, 0, 'root page user sees no reminders');
   });
 });
 
 test('adding a new item', function(assert) {
-  server.createList('reminder', 5);
 
   visit('/');
   click('.spec-reminder--new');
@@ -42,7 +28,7 @@ test('adding a new item', function(assert) {
   click('.spec-reminder--title:last');
 
   andThen(function() {
-    assert.equal(currentURL(), '/reminders/6', 'current url is /reminders/6');
+    assert.equal(currentURL(), '/reminders/1', 'current url is /reminders/1');
     assert.equal(Ember.$('.spec-reminder-card--title:last').text().trim(), 'Bananas', 'adds title to reminder list on submit');
     assert.equal(Ember.$('.spec-reminder-card--date:last').text().trim(), '12/23/16', 'adds date to reminder list on submit');
   });

--- a/tests/integration/components/edit-reminder-test.js
+++ b/tests/integration/components/edit-reminder-test.js
@@ -17,5 +17,5 @@ test('it renders a text area', function(assert) {
 
 test('it renders a button', function(assert) {
   this.render(hbs`{{edit-reminder}}`);
-  assert.equal(this.$('button').length, 2);
+  assert.equal(this.$('button').length, 1);
 });

--- a/tests/integration/components/edit-reminder-test.js
+++ b/tests/integration/components/edit-reminder-test.js
@@ -17,5 +17,5 @@ test('it renders a text area', function(assert) {
 
 test('it renders a button', function(assert) {
   this.render(hbs`{{edit-reminder}}`);
-  assert.equal(this.$('button').length, 1);
+  assert.equal(this.$('button').length, 2);
 });


### PR DESCRIPTION
## Purpose
User can revert an unsaved reminder to its previous state mid-edit.

When actively editing a reminder, if the reminder has unsaved changes, the user will see a button to rollback unsaved changes.
When clicked it will automatically rollback the attributes of the reminder to its original, clean state.
Pro tip: If you’re doing something that seems hard, maybe you should check the Ember Data API docs for a hint...

[Issue #12](https://github.com/turingschool-projects/1610-remember-1/issues/12)

## Approach

We just created a 'revert' button that called an action called 'revertReminder.' We then added that function to the edit component and used model.rollback().

### Learning

Just referenced Ember docs

[Ember Rollback Docs](http://emberjs.com/api/data/classes/DS.Model.html#method_rollbackAttributes)

### Open Questions and Pre-Merge TODOs

- [x] Add revert button and action to roll back attributes
- [x] Fix broken acceptance tests
- [x] Add new acceptance tests

### Test coverage 

We wrote a test that visits the page, enters data, hits submit, clicks on entry, clicks edit button, fills in changed text, hits the 'revert' button, and checks to see that the text did not change.

### Follow-up tasks

- [Issue #13](https://github.com/turingschool-projects/1610-remember-1/issues/13)

### Screenshots

#### Before
<img width="600" alt="screen shot 2017-02-14 at 3 44 52 pm" src="https://cloud.githubusercontent.com/assets/20376939/22953018/8f1fe550-f2cc-11e6-96c3-b6dbc2784620.png">

#### After
<img width="469" alt="screen shot 2017-02-14 at 3 21 21 pm" src="https://cloud.githubusercontent.com/assets/20376939/22952285/9810f936-f2c9-11e6-8943-d9e351c0c101.png">
<img width="541" alt="screen shot 2017-02-14 at 3 21 38 pm" src="https://cloud.githubusercontent.com/assets/20376939/22952305/afd63504-f2c9-11e6-8cf2-56f6a78ca0ae.png">
<img width="469" alt="screen shot 2017-02-14 at 3 21 21 pm" src="https://cloud.githubusercontent.com/assets/20376939/22952308/b1e7d91a-f2c9-11e6-8a2e-3a5c77ea06c1.png">
<img width="478" alt="screen shot 2017-02-14 at 3 18 35 pm" src="https://cloud.githubusercontent.com/assets/20376939/22952312/b4efc0c8-f2c9-11e6-92fb-0d7fcee03291.png">
<img width="572" alt="screen shot 2017-02-14 at 3 17 51 pm" src="https://cloud.githubusercontent.com/assets/20376939/22952320/baf7a38c-f2c9-11e6-8a45-b83f35c38d1d.png">

close #11 
close #12 