### PR TITLE
Put new class on h3 if it is dirty

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -3,6 +3,10 @@ li a {
   color: black;
 }
 
-li a.active h3{
+li a.active h3 {
   background-color: pink;
+}
+
+.please-save-me {
+  color: gray;
 }

--- a/app/templates/components/reminders-list.hbs
+++ b/app/templates/components/reminders-list.hbs
@@ -10,9 +10,13 @@
   {{#if model}}
     {{#each model as |reminder|}}
       <li class='spec-reminder-item'>
-        {{#link-to "reminders.reminder-card" reminder}}
+      {{#link-to "reminders.reminder-card" reminder}}
+        {{#if reminder.hasDirtyAttributes}}
+          <h3 class='spec-reminder--title please-save-me'>{{reminder.title}}</h3>
+        {{else}}
           <h3 class='spec-reminder--title'>{{reminder.title}}</h3>
-        {{/link-to}}
+        {{/if}}
+      {{/link-to}}
       </li>
     {{/each}}
   {{else}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -89,6 +89,11 @@ test('edit and revert to original info', function(assert) {
   fillIn('.spec-textarea-notes', 'This shit is bananas, B.A.N.A.N.A.S.');
   click('.spec-reminder-add--submit');
   click('.spec-reminder--title');
+
+  andThen(function() {
+    assert.equal(Ember.$('.please-save-me').length, 0, 'There is no unsaved classname before we edit')
+  })
+
   click('.spec-reminder-card--editbtn');
 
   andThen(function() {
@@ -98,6 +103,11 @@ test('edit and revert to original info', function(assert) {
   fillIn('.spec-edit-input-title', 'a');
   fillIn('.spec-edit-input-date', 'a');
   fillIn('.spec-edit-textarea-notes', 'a');
+
+  andThen(function() {
+    assert.equal(Ember.$('.please-save-me').length, 1, 'There is an unsaved classname while editing')
+  })
+
   click('.spec-reminder-edit--revert');
 
   andThen(function() {


### PR DESCRIPTION
## Purpose

User sees visual cue that reminder has not been saved.

When a reminder has changes that have not been saved to the database/server, the user should see some kind of visual indication in the sidebar of the application on that particular note.
[Issue #13](https://github.com/turingschool-projects/1610-remember-1/issues/13)

## Approach

We figured the style needed to change based on a condition so we threw an if statement into our reminders template to check if a reminder was dirty.

### Learning

No research.

### Open Questions and Pre-Merge TODOs

- [x] Put new class on h3 if it's dirty
- [x] Wrote a few acceptance tests determining whether there is an unsaved class on our h3

### Test coverage 

checked before and after editing a reminder to see if class shows up.

### Follow-up tasks

- [Issue #14](https://github.com/turingschool-projects/1610-remember-1/issues/14)

### Screenshots

#### Before
<img width="541" alt="screen shot 2017-02-14 at 3 21 38 pm" src="https://cloud.githubusercontent.com/assets/20376939/22955854/c4251694-f2db-11e6-8174-9c27fe5cfe49.png">

#### After
<img width="533" alt="screen shot 2017-02-14 at 5 30 22 pm" src="https://cloud.githubusercontent.com/assets/20376939/22955835/b0d39e30-f2db-11e6-95b5-12e3392c5f2e.png">
The text turns grey when it is not saved!
<img width="404" alt="screen shot 2017-02-14 at 5 29 19 pm" src="https://cloud.githubusercontent.com/assets/20376939/22955848/bd85af24-f2db-11e6-9496-7a2cce688a78.png">


close #13